### PR TITLE
Update DockerListener.py to append sha256 Docker image ID

### DIFF
--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -108,12 +108,16 @@ class DockerListener:
 
     def format_msg(self, msg):
         """
-        Formats a Docker event
+        Formats a Docker event and appends docker image ID if available
 
         :param msg: message to be formatted.
         :return: formatted message.
         """
-        return {'integration': 'docker', 'docker': json.loads(msg)}
+        msg = json.loads(msg)
+        if 'from' in msg:
+            image = self.client.images.get(msg['from'])
+            msg['imageID'] = image.id
+        return {'integration': 'docker', 'docker': msg}
 
     def send_msg(self, msg):
         """


### PR DESCRIPTION
## Description

Small change to append sha256 Docker image ID to Docker listener events
Useful for tracking container activity with mutable image tags

## Configuration options

n/a

## Logs/Alerts example

New field imageID:
```
{
  "status": "start",
  "id": "0abdc1d0a9dec726d413223f7c6496360d4d1919a1d1a250d8aec2b3733b43e3",
  "imageID": "sha256:xxxxxxxx00f510dabbd8f5536691f476d5af7c21218605dc8f955f3b6fc09c53"
  "from": "example-image:latest",
  "Type": "container",
  "Action": "start",
  "Actor": {
    "ID": "0abdc1d0a9dec726d413223f7c6496360d4d1919a1d1a250d8aec2b3733b43e3",
    "Attributes": {
      "name": "example"
    }
  },
  "scope": "local",
  "time": 1583848894,
  "timeNano": 1583848894507672800
}
```